### PR TITLE
Add active-directory-home test case and improve script

### DIFF
--- a/test/fixtures/active-directory-home/code.js
+++ b/test/fixtures/active-directory-home/code.js
@@ -1,0 +1,167 @@
+import { $, internal } from '@okta/core.common';
+import sinon from 'sinon';
+import AdHomeRouter from '../../src/AdHomeRouter';
+import { ProvisionSettingsMultiTabController, AssignmentsController, ConvertAssigmentUtil, SignOnPreviewController }
+  from '@okta/admin.appinstance/main/active-directory-home';
+import { Controller as UserAssignmentController } from '@okta/admin.userassignment/main/appinstance';
+import { ADGroupPushController } from '@okta/admin.grouppush';
+
+const SettingsModel = internal.util.SettingsModel;
+
+describe('active-directory-home/AdHomeRouter', function() {
+  let ss;
+  let router;
+  let stub;
+  const stubFunc = (sandbox) => ({
+    hasFeature: sandbox.stub(SettingsModel.prototype, 'hasFeature'),
+    multiTabController: sandbox.stub(ProvisionSettingsMultiTabController.prototype, 'initialize'),
+    multiTabControllerRender: sandbox.stub(ProvisionSettingsMultiTabController.prototype, 'render'),
+    multiTabControllerRemove: sandbox.stub(ProvisionSettingsMultiTabController.prototype, 'remove'),
+    userAssignmentController: sandbox.stub(UserAssignmentController.prototype, 'initialize'),
+    userAssignmentControllerRender: sandbox.stub(UserAssignmentController.prototype, 'render'),
+    userAssignmentControllerRemove: sandbox.stub(UserAssignmentController.prototype, 'remove'),
+    assignmentsController: sandbox.stub(AssignmentsController.prototype, 'initialize'),
+    assignmentsControllerRender: sandbox.stub(AssignmentsController.prototype, 'render'),
+    convertAssignmentUtilInit: sandbox.stub(ConvertAssigmentUtil, 'init'),
+    adGroupPushController: sandbox.stub(ADGroupPushController.prototype, 'initialize'),
+    adGroupPushControllerRender: sandbox.stub(ADGroupPushController.prototype, 'render'),
+    adGroupPushControllerRemove: sandbox.stub(ADGroupPushController.prototype, 'remove'),
+    signOnPreviewControllerRender: sandbox.stub(SignOnPreviewController.prototype, 'render'),
+    signOnPreviewControllerRemove: sandbox.stub(SignOnPreviewController.prototype, 'remove'),
+    navigate: sandbox.stub(AdHomeRouter.prototype, 'navigate'),
+  });
+
+  beforeEach(function() {
+    ss = sinon.createSandbox();
+    stub = stubFunc(ss);
+    router = new AdHomeRouter({
+      getGeneralTabLoadedPromise: () => $.Deferred().resolve(),
+    });
+  });
+
+  afterEach(function() {
+    if (router && router.controller) {
+      router._unloadAdditionalControllers();
+      router.unload();
+    }
+
+    ss.restore();
+  });
+
+  it('Defaults to the assignments tab if SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD is enabled.', function() {
+    stub.hasFeature.withArgs('SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD').returns(true);
+    router.navigateDefault();
+
+    expect(stub.navigate.calledWith('tab-assignments', { trigger: true })).toEqual(true);
+  });
+
+  it('Defaults to the people tab if SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD is disabled.', function() {
+    stub.hasFeature.withArgs('SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD').returns(false);
+    router.navigateDefault();
+
+    expect(stub.navigate.calledWith('tab-people', { trigger: true })).toEqual(true);
+  });
+
+  it('Renders the ProvisioningSettingsMultiTabController when navigating to the general tab', function() {
+    stub.hasFeature.withArgs('AD_PROVISIONING').returns(true);
+    router.navigateGeneral();
+
+    expect(
+      stub.multiTabController.calledWith(
+        sinon.match({
+          renderNoAdProvisioningMessage: false,
+        }),
+      ),
+    ).toBe(true);
+
+    expect(stub.multiTabControllerRender.calledOnce).toBe(true);
+  });
+
+  it('Renders SignOnPreviewController on general tab if ENG_NEW_AD_INSTANCE_USING_UD_MAPPING enabled', function() {
+    stub.hasFeature.withArgs('ENG_NEW_AD_INSTANCE_USING_UD_MAPPING').returns(true);
+    router.navigateGeneral();
+
+    expect(stub.signOnPreviewControllerRender.calledOnce).toBe(true);
+  });
+
+  it('Omits SignOnPreviewController on general tab if ENG_NEW_AD_INSTANCE_USING_UD_MAPPING disabled', function() {
+    stub.hasFeature.withArgs('ENG_NEW_AD_INSTANCE_USING_UD_MAPPING').returns(false);
+    router.navigateGeneral();
+
+    expect(stub.signOnPreviewControllerRender.notCalled).toBe(true);
+  });
+
+  it('Renders "Provisioning not available for AD" message when AD_PROVISIONING is disabled', function() {
+    stub.hasFeature.withArgs('AD_PROVISIONING').returns(false);
+    router.navigateGeneral();
+
+    expect(
+      stub.multiTabController.calledWith(
+        sinon.match({
+          renderNoAdProvisioningMessage: true,
+        }),
+      ),
+    ).toBe(true);
+
+    expect(stub.multiTabControllerRender.calledOnce).toBe(true);
+  });
+
+  it('Renders the UserAssignmentController when navigating to the general tab', function() {
+    router.navigatePeople();
+
+    expect(router.controller).toEqual(expect.any(UserAssignmentController));
+    expect(stub.userAssignmentController.calledOnce).toBe(true);
+    expect(stub.userAssignmentControllerRender.calledOnce).toBe(true);
+  });
+
+  it('Renders the ADGroupPushController when navigating to the group push tab', function() {
+    router.navigateGroupPush();
+
+    expect(router.controller).toEqual(expect.any(ADGroupPushController));
+    expect(stub.adGroupPushController.calledOnce).toBe(true);
+    expect(stub.adGroupPushControllerRender.calledOnce).toBe(true);
+  });
+
+  it('Renders the AssignmentsController when navigating to the assignments tab', function() {
+    router.navigateAssignments();
+
+    expect(router.controller).toEqual(expect.any(AssignmentsController));
+    expect(stub.assignmentsController.calledOnce).toBe(true);
+    expect(stub.assignmentsControllerRender.calledOnce).toBe(true);
+    expect(stub.convertAssignmentUtilInit.calledWith(router.controller.state)).toBe(true);
+  });
+
+  it('Clears the current controller when navigating to an unrecognized hash URL', function() {
+    stub.hasFeature.withArgs('ENG_NEW_AD_INSTANCE_USING_UD_MAPPING').returns(true);
+
+    // Loads the controller.
+    router.navigateGeneral();
+    expect(router.controller instanceof ProvisionSettingsMultiTabController).toBe(true);
+    expect(stub.multiTabController.called).toBe(true);
+    expect(stub.signOnPreviewControllerRender.calledOnce).toBe(true);
+    expect(stub.multiTabControllerRemove.notCalled).toBe(true);
+
+    // Unloads the controller.
+    router.navigateAway();
+    expect(router.controller).toBe(null);
+    expect(stub.multiTabControllerRemove.calledOnce).toBe(true);
+    expect(stub.signOnPreviewControllerRemove.calledOnce).toBe(true);
+  });
+
+  it('Updates the hash URL when the user navigates between settings sections.', function() {
+    router.navigateGeneral();
+    expect(router.controller).toEqual(expect.any(ProvisionSettingsMultiTabController));
+
+    router.controller.state.set('provisionSubFilter', 'import-n-mastering');
+    expect(stub.navigate.calledWith('tab-general/import-n-mastering')).toBe(true);
+
+    router.controller.state.set('provisionSubFilter', 'create-n-update');
+    expect(stub.navigate.calledWith('tab-general/create-n-update')).toBe(true);
+
+    router.controller.state.set('provisionSubFilter', null);
+    expect(stub.navigate.calledWith('tab-general')).toBe(true);
+
+    router.controller.state.set('provisionSubFilter', '');
+    expect(stub.navigate.calledWith('tab-general')).toBe(true);
+  });
+});

--- a/test/fixtures/active-directory-home/output.js
+++ b/test/fixtures/active-directory-home/output.js
@@ -1,0 +1,129 @@
+import { $, internal } from '@okta/core.common';
+import AdHomeRouter from '../../src/AdHomeRouter';
+import { ProvisionSettingsMultiTabController, AssignmentsController, ConvertAssigmentUtil, SignOnPreviewController } from '@okta/admin.appinstance/main/active-directory-home';
+import { Controller as UserAssignmentController } from '@okta/admin.userassignment/main/appinstance';
+import { ADGroupPushController } from '@okta/admin.grouppush';
+const SettingsModel = internal.util.SettingsModel;
+describe('active-directory-home/AdHomeRouter', function () {
+  let ss;
+  let router;
+  let stub;
+
+  const stubFunc = sandbox => ({
+    hasFeature: jest.spyOn(SettingsModel.prototype, 'hasFeature').mockImplementation(() => {}),
+    multiTabController: jest.spyOn(ProvisionSettingsMultiTabController.prototype, 'initialize').mockImplementation(() => {}),
+    multiTabControllerRender: jest.spyOn(ProvisionSettingsMultiTabController.prototype, 'render').mockImplementation(() => {}),
+    multiTabControllerRemove: jest.spyOn(ProvisionSettingsMultiTabController.prototype, 'remove').mockImplementation(() => {}),
+    userAssignmentController: jest.spyOn(UserAssignmentController.prototype, 'initialize').mockImplementation(() => {}),
+    userAssignmentControllerRender: jest.spyOn(UserAssignmentController.prototype, 'render').mockImplementation(() => {}),
+    userAssignmentControllerRemove: jest.spyOn(UserAssignmentController.prototype, 'remove').mockImplementation(() => {}),
+    assignmentsController: jest.spyOn(AssignmentsController.prototype, 'initialize').mockImplementation(() => {}),
+    assignmentsControllerRender: jest.spyOn(AssignmentsController.prototype, 'render').mockImplementation(() => {}),
+    convertAssignmentUtilInit: jest.spyOn(ConvertAssigmentUtil, 'init').mockImplementation(() => {}),
+    adGroupPushController: jest.spyOn(ADGroupPushController.prototype, 'initialize').mockImplementation(() => {}),
+    adGroupPushControllerRender: jest.spyOn(ADGroupPushController.prototype, 'render').mockImplementation(() => {}),
+    adGroupPushControllerRemove: jest.spyOn(ADGroupPushController.prototype, 'remove').mockImplementation(() => {}),
+    signOnPreviewControllerRender: jest.spyOn(SignOnPreviewController.prototype, 'render').mockImplementation(() => {}),
+    signOnPreviewControllerRemove: jest.spyOn(SignOnPreviewController.prototype, 'remove').mockImplementation(() => {}),
+    navigate: jest.spyOn(AdHomeRouter.prototype, 'navigate').mockImplementation(() => {})
+  });
+
+  beforeEach(function () {
+    stub = stubFunc(ss);
+    router = new AdHomeRouter({
+      getGeneralTabLoadedPromise: () => $.Deferred().resolve()
+    });
+  });
+  afterEach(function () {
+    if (router && router.controller) {
+      router._unloadAdditionalControllers();
+
+      router.unload();
+    }
+  });
+  it('Defaults to the assignments tab if SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD is enabled.', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD' ? true : null);
+    router.navigateDefault();
+    expect(stub.navigate).toHaveBeenCalledWith('tab-assignments', {
+      trigger: true
+    });
+  });
+  it('Defaults to the people tab if SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD is disabled.', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD' ? false : null);
+    router.navigateDefault();
+    expect(stub.navigate).toHaveBeenCalledWith('tab-people', {
+      trigger: true
+    });
+  });
+  it('Renders the ProvisioningSettingsMultiTabController when navigating to the general tab', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'AD_PROVISIONING' ? true : null);
+    router.navigateGeneral();
+    expect(stub.multiTabController).toHaveBeenCalledWith(expect.objectContaining({
+      renderNoAdProvisioningMessage: false
+    }));
+    expect(stub.multiTabControllerRender).toHaveBeenCalledTimes(1);
+  });
+  it('Renders SignOnPreviewController on general tab if ENG_NEW_AD_INSTANCE_USING_UD_MAPPING enabled', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'ENG_NEW_AD_INSTANCE_USING_UD_MAPPING' ? true : null);
+    router.navigateGeneral();
+    expect(stub.signOnPreviewControllerRender).toHaveBeenCalledTimes(1);
+  });
+  it('Omits SignOnPreviewController on general tab if ENG_NEW_AD_INSTANCE_USING_UD_MAPPING disabled', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'ENG_NEW_AD_INSTANCE_USING_UD_MAPPING' ? false : null);
+    router.navigateGeneral();
+    expect(stub.signOnPreviewControllerRender).not.toHaveBeenCalled();
+  });
+  it('Renders "Provisioning not available for AD" message when AD_PROVISIONING is disabled', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'AD_PROVISIONING' ? false : null);
+    router.navigateGeneral();
+    expect(stub.multiTabController).toHaveBeenCalledWith(expect.objectContaining({
+      renderNoAdProvisioningMessage: true
+    }));
+    expect(stub.multiTabControllerRender).toHaveBeenCalledTimes(1);
+  });
+  it('Renders the UserAssignmentController when navigating to the general tab', function () {
+    router.navigatePeople();
+    expect(router.controller).toEqual(expect.any(UserAssignmentController));
+    expect(stub.userAssignmentController).toHaveBeenCalledTimes(1);
+    expect(stub.userAssignmentControllerRender).toHaveBeenCalledTimes(1);
+  });
+  it('Renders the ADGroupPushController when navigating to the group push tab', function () {
+    router.navigateGroupPush();
+    expect(router.controller).toEqual(expect.any(ADGroupPushController));
+    expect(stub.adGroupPushController).toHaveBeenCalledTimes(1);
+    expect(stub.adGroupPushControllerRender).toHaveBeenCalledTimes(1);
+  });
+  it('Renders the AssignmentsController when navigating to the assignments tab', function () {
+    router.navigateAssignments();
+    expect(router.controller).toEqual(expect.any(AssignmentsController));
+    expect(stub.assignmentsController).toHaveBeenCalledTimes(1);
+    expect(stub.assignmentsControllerRender).toHaveBeenCalledTimes(1);
+    expect(stub.convertAssignmentUtilInit).toHaveBeenCalledWith(router.controller.state);
+  });
+  it('Clears the current controller when navigating to an unrecognized hash URL', function () {
+    stub.hasFeature.mockImplementation(arg => arg === 'ENG_NEW_AD_INSTANCE_USING_UD_MAPPING' ? true : null); // Loads the controller.
+
+    router.navigateGeneral();
+    expect(router.controller instanceof ProvisionSettingsMultiTabController).toBe(true);
+    expect(stub.multiTabController).toHaveBeenCalled();
+    expect(stub.signOnPreviewControllerRender).toHaveBeenCalledTimes(1);
+    expect(stub.multiTabControllerRemove).not.toHaveBeenCalled(); // Unloads the controller.
+
+    router.navigateAway();
+    expect(router.controller).toBe(null);
+    expect(stub.multiTabControllerRemove).toHaveBeenCalledTimes(1);
+    expect(stub.signOnPreviewControllerRemove).toHaveBeenCalledTimes(1);
+  });
+  it('Updates the hash URL when the user navigates between settings sections.', function () {
+    router.navigateGeneral();
+    expect(router.controller).toEqual(expect.any(ProvisionSettingsMultiTabController));
+    router.controller.state.set('provisionSubFilter', 'import-n-mastering');
+    expect(stub.navigate).toHaveBeenCalledWith('tab-general/import-n-mastering');
+    router.controller.state.set('provisionSubFilter', 'create-n-update');
+    expect(stub.navigate).toHaveBeenCalledWith('tab-general/create-n-update');
+    router.controller.state.set('provisionSubFilter', null);
+    expect(stub.navigate).toHaveBeenCalledWith('tab-general');
+    router.controller.state.set('provisionSubFilter', '');
+    expect(stub.navigate).toHaveBeenCalledWith('tab-general');
+  });
+});

--- a/test/fixtures/example/output.js
+++ b/test/fixtures/example/output.js
@@ -1,11 +1,11 @@
-describe("timeout-enforcement/models/TimeoutEnforcement", () => {
+describe('timeout-enforcement/models/TimeoutEnforcement', () => {
   let testContext;
   beforeEach(() => {
     testContext = {};
     jest.useFakeTimers();
     testContext.foo = "abc";
   });
-  it("has a Model and a Collection", () => {
+  it('has a Model and a Collection', () => {
     jest.advanceTimersByTime(100);
     expect(TimeoutEnforcement.Model).toBeDefined();
     expect(TimeoutEnforcement.Collection).toBeDefined();

--- a/test/fixtures/sinon-spy/output.js
+++ b/test/fixtures/sinon-spy/output.js
@@ -1,24 +1,24 @@
-describe("sinon-spy", () => {
+describe('sinon-spy', () => {
   let testContext;
   const obj = {
-    method: (num) => num + 10,
-    add: (a, b) => a + b,
+    method: num => num + 10,
+    add: (a, b) => a + b
   };
 
   function setupMock(ss) {
     this.stubs = {
-      add: jest.spyOn(obj, "add"),
+      add: jest.spyOn(obj, 'add')
     };
   }
 
   beforeEach(() => {
     testContext = {};
     testContext.spies = {
-      method: jest.spyOn(obj, "method"),
+      method: jest.spyOn(obj, 'method')
     };
     setupMock.call(testContext, testContext.ss);
   });
-  it("spy on method", () => {
+  it('spy on method', () => {
     jest.useFakeTimers();
     expect(obj.method(5)).toBe(15);
     jest.advanceTimersByTime(100);

--- a/test/fixtures/sinon-stub/output.js
+++ b/test/fixtures/sinon-stub/output.js
@@ -1,28 +1,28 @@
-describe("sinon-stub", () => {
+describe('sinon-stub', () => {
   let testContext;
   const obj = {
-    method: (num) => num + 10,
+    method: num => num + 10,
     add: (a, b) => a + b,
-    refresh: () => {},
+    refresh: () => {}
   };
 
   function setupMock(ss) {
     this.stubs = {
-      add: jest.spyOn(obj, "add").mockImplementation(() => {
+      add: jest.spyOn(obj, 'add').mockImplementation(() => {
         return $.Deferred().resolve();
       }),
-      refresh: jest.spyOn(obj, "refresh").mockImplementation(() => {}),
+      refresh: jest.spyOn(obj, 'refresh').mockImplementation(() => {})
     };
   }
 
   beforeEach(() => {
     testContext = {};
     testContext.spies = {
-      method: jest.spyOn(obj, "method"),
+      method: jest.spyOn(obj, 'method')
     };
     setupMock.call(testContext, testContext.ss);
   });
-  it("spy on method", () => {
+  it('spy on method', () => {
     expect(obj.method(5)).toBe(15);
     expect(testContext.spies.method).toHaveBeenCalled();
     expect(testContext.stubs.add).not.toHaveBeenCalled();

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,8 +1,10 @@
 const path = require('path');
-const pluginTester = require('babel-plugin-tester').default;
+const pluginTester = require('babel-plugin-tester/pure').default;
 const plugin = require('../src');
 
 pluginTester({
   plugin: plugin,
   fixtures: path.join(__dirname, 'fixtures'),
+  snapshot: true,
+  formatResult: r => r,
 });


### PR DESCRIPTION
Add active-directory-home test case and improve script

Test output after conversion:

```
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
 FAIL  test/spec/AdHomeRouter_spec.js
  active-directory-home/AdHomeRouter
    ✓ Defaults to the assignments tab if SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD is enabled. (5 ms)
    ✓ Defaults to the people tab if SUPPORT_USER_MOVES_ACROSS_OUS_IN_AD is disabled. (1 ms)
    ✓ Renders the ProvisioningSettingsMultiTabController when navigating to the general tab (3 ms)
    ✓ Renders SignOnPreviewController on general tab if ENG_NEW_AD_INSTANCE_USING_UD_MAPPING enabled (3 ms)
    ✓ Omits SignOnPreviewController on general tab if ENG_NEW_AD_INSTANCE_USING_UD_MAPPING disabled (1 ms)
    ✓ Renders "Provisioning not available for AD" message when AD_PROVISIONING is disabled (1 ms)
    ✓ Renders the UserAssignmentController when navigating to the general tab (2 ms)
    ✓ Renders the ADGroupPushController when navigating to the group push tab (1 ms)
    ✓ Renders the AssignmentsController when navigating to the assignments tab (2 ms)
    ✓ Clears the current controller when navigating to an unrecognized hash URL (2 ms)
    ✕ Updates the hash URL when the user navigates between settings sections. (4 ms)

  ● active-directory-home/AdHomeRouter › Updates the hash URL when the user navigates between settings sections.

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "tab-general/import-n-mastering"
    Received: "tab-general/import-n-mastering", {"replace": true}

    Number of calls: 1

      119 |     expect(router.controller).toEqual(expect.any(ProvisionSettingsMultiTabController));
      120 |     router.controller.state.set('provisionSubFilter', 'import-n-mastering');
    > 121 |     expect(stub.navigate).toHaveBeenCalledWith('tab-general/import-n-mastering');
          |                           ^
      122 |     router.controller.state.set('provisionSubFilter', 'create-n-update');
      123 |     expect(stub.navigate).toHaveBeenCalledWith('tab-general/create-n-update');
      124 |     router.controller.state.set('provisionSubFilter', null);

      at Object.toHaveBeenCalledWith (test/spec/AdHomeRouter_spec.js:121:27)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 10 passed, 11 total
Snapshots:   0 total
Time:        3.823 s
Ran all test suites related to changed files.

Watch Usage
 › Press a to run all tests.
 › Press f to run only failed tests.
 › Press p to filter by a filename regex pattern.
 › Press t to filter by a test name regex pattern.
 › Press q to quit watch mode.
 › Press Enter to trigger a test run.


✨  Done in 8.89s.
```